### PR TITLE
Switch from Stack to Construct For Scope Type

### DIFF
--- a/src/nodeFunctions/AppsyncNodejsResolver.ts
+++ b/src/nodeFunctions/AppsyncNodejsResolver.ts
@@ -1,5 +1,5 @@
 import { NodejsFunctionProps } from "@aws-cdk/aws-lambda-nodejs";
-import { Stack } from "@aws-cdk/core";
+import { Construct } from "@aws-cdk/core";
 import {
   IGraphqlApi,
   LambdaDataSource,
@@ -19,7 +19,7 @@ import SkyhookNodejsFunction from "./SkyhookNodejsFunction";
  */
 export default class AppsyncNodejsResolver extends SkyhookNodejsFunction {
   constructor(
-    scope: Stack,
+    scope: Construct,
     id: string,
     { api, typeName, fieldName, entry, handler }: LambdaMutationResolverProps
   ) {

--- a/src/nodeFunctions/EventBridgeNodejsListener.ts
+++ b/src/nodeFunctions/EventBridgeNodejsListener.ts
@@ -1,7 +1,7 @@
 import { Alarm } from "@aws-cdk/aws-cloudwatch";
 import { NodejsFunctionProps } from "@aws-cdk/aws-lambda-nodejs";
 import { Rule, RuleProps } from "@aws-cdk/aws-events";
-import { Stack, Duration } from "@aws-cdk/core";
+import { Duration, Construct } from "@aws-cdk/core";
 import { LambdaFunction } from "@aws-cdk/aws-events-targets";
 import { Queue } from "@aws-cdk/aws-sqs";
 import SkyhookNodejsFunction from "./SkyhookNodejsFunction";
@@ -15,7 +15,7 @@ import SkyhookNodejsFunction from "./SkyhookNodejsFunction";
  */
 export default class EventBridgeNodejsListener extends SkyhookNodejsFunction {
   constructor(
-    scope: Stack,
+    scope: Construct,
     id: string,
     {
       description,

--- a/src/nodeFunctions/SkyhookNodejsFunction.ts
+++ b/src/nodeFunctions/SkyhookNodejsFunction.ts
@@ -3,7 +3,7 @@ import {
   NodejsFunctionProps,
 } from "@aws-cdk/aws-lambda-nodejs";
 import { Runtime } from "@aws-cdk/aws-lambda";
-import { Stack } from "@aws-cdk/core";
+import { Construct } from "@aws-cdk/core";
 
 /**
  * Skyhook Nodejs Function
@@ -16,7 +16,7 @@ import { Stack } from "@aws-cdk/core";
  * using esbuild, which is much faster than webpack.
  */
 export default class SkyhookNodejsFunction extends NodejsFunction {
-  constructor(scope: Stack, id: string, props: NodejsFunctionProps) {
+  constructor(scope: Construct, id: string, props: NodejsFunctionProps) {
     super(scope, id, {
       // Skyhook defaults
       bundling: { minify: true },


### PR DESCRIPTION
Constrruct is compatible with more cdk types allowing it to be used away from the stack level.